### PR TITLE
• Correct change macro

### DIFF
--- a/drivers/Inc/stm32f103xx.h
+++ b/drivers/Inc/stm32f103xx.h
@@ -30,9 +30,9 @@
 /*
  * ARM Cortex M3 Processor Priority Register Address Calculation
  */
-#define NVIC_PR_BASE_ADDR 				((__vo uint32_t*)0xE000E400)
+#define NVIC_PRIOR_BASE_ADDR 				((__vo uint32_t*)0xE000E400)
 
-#define NO_PR_BITS_IMPLEMENTED			4
+#define NO_PRIOR_BITS_IMPLEMENTED			4
 
 
 /*	Base Address of Flash and SRAM memories	*/

--- a/drivers/Src/stm32f103xx_gpio_driver.c
+++ b/drivers/Src/stm32f103xx_gpio_driver.c
@@ -354,8 +354,8 @@ void GPIO_IRQPriorityConfig(uint8_t IRQNumber, uint32_t IRQPriority)
 	uint8_t iprx_section = IRQNumber % 4;
 
 
-	uint8_t shift_amount = ( 8 * iprx_section)+ ( 8 - NO_PR_BITS_IMPLEMENTED );
-	*(NVIC_PR_BASE_ADDR + iprx) |= (IRQPriority << (8 * shift_amount));
+	uint8_t shift_amount = ( 8 * iprx_section)+ ( 8 - NO_PRIOR_BITS_IMPLEMENTED );
+	*(NVIC_PRIOR_BASE_ADDR + iprx) |= (IRQPriority << (8 * shift_amount));
 
 
 }


### PR DESCRIPTION
- NVIC_PR_BASE_ADDR -> NVIC_PRIOR_BASE_ADDR
- NO_PR_BITS_IMPLEMENTED -> NO_PRIOR_BITS_IMPLEMENTED